### PR TITLE
Lets user use number keys to set ranking 

### DIFF
--- a/javascript/images_history.js
+++ b/javascript/images_history.js
@@ -190,3 +190,37 @@ document.addEventListener("DOMContentLoaded", function() {
     });
     mutationObserver.observe(gradioApp(), { childList:true, subtree:true });
 });
+
+function getCurrentTabName() {
+    var tabs = gradioApp().getElementById("images_history_tab").querySelectorAll('[id$="_images_history_container"]');
+
+    for (const element of tabs) {
+      if (element.style.display === "block") {
+        const id = element.id;
+        const index = id.indexOf("_images_history_container");
+        const tabname = id.substring(0, index);
+        return tabname;
+      }
+    }
+}
+
+gradioApp().addEventListener("keydown", function(event) {
+    // If we are not on the Image Browser Extension, dont listen for keypresses
+    var ext_active = gradioApp().getElementById("tab_images_history");
+    if (!ext_active || ext_active.style.display === "none") {
+        return;
+    }
+
+    // Listens for keypresses 0-5 and updates the corresponding ranking (0 is the last option, None)
+    if (event.code >= "Digit0" && event.code <= "Digit5") {
+        var selectedValue = event.code.charAt(event.code.length - 1);
+        var radioInputs = gradioApp().getElementById( getCurrentTabName() + "_images_ranking").getElementsByTagName("input");
+        for (const input of radioInputs) {
+            if (input.value === selectedValue || (selectedValue === '0' && input === radioInputs[radioInputs.length - 1])) {
+                input.checked = true;
+                input.dispatchEvent(new Event("change"));
+                break;
+            }
+        }
+    }
+});

--- a/javascript/images_history.js
+++ b/javascript/images_history.js
@@ -103,7 +103,7 @@ function images_history_delete(del_num, tabname, image_index){
             buttons[image_index + i + img_num].style.display = 'none';
             next_img = image_index + i + 1
         }
-        var bnt;
+        var btn;
         if (next_img  >= img_num){
             btn = buttons[image_index - 1];
         } else {            
@@ -165,16 +165,20 @@ document.addEventListener("DOMContentLoaded", function() {
             for (var i in images_history_tab_list ){
                 let tabname = images_history_tab_list[i]
                 var buttons = gradioApp().querySelectorAll('#' + tabname + '_images_history .gallery-item');
-                buttons.forEach(function(bnt){    
-                    bnt.addEventListener('click', images_history_click_image, true);
-                    document.onkeyup = function(e){
+                buttons.forEach(function(button){    
+                    button.addEventListener('click', images_history_click_image, true);
+                    document.onkeyup = function(e) {
+                        if (!checkImageBrowserActive()) {
+                            return;
+                        }
                         clearTimeout(timer)
                         timer = setTimeout(() => {
-                            let tab = gradioApp().getElementById("tab_images_history").getElementsByClassName("bg-white px-4 pb-2 pt-1.5 rounded-t-lg border-gray-200 -mb-[2px] border-2 border-b-0")[0].innerText
-                            bnt = gradioApp().getElementById(tab+"_images_history_gallery").getElementsByClassName('gallery-item !flex-none !h-9 !w-9 transition-all duration-75 !ring-2 !ring-orange-500 hover:!ring-orange-500 svelte-1g9btlg')[0]
-                            images_history_click_image.call(bnt)
-                        },500)
-                      
+                            var gallery_btn = gradioApp().getElementById(getCurrentTabName() +"_images_history_gallery").getElementsByClassName('gallery-item !flex-none !h-9 !w-9 transition-all duration-75 !ring-2 !ring-orange-500 hover:!ring-orange-500 svelte-1g9btlg');
+                            gallery_btn = gallery_btn && gallery_btn.length > 0 ? gallery_btn[0] : null;
+                            if (gallery_btn) {
+                                images_history_click_image.call(gallery_btn)
+                            }
+                        }, 500);
                     }
                 });
 
@@ -204,10 +208,14 @@ function getCurrentTabName() {
     }
 }
 
+function checkImageBrowserActive() {
+    var ext_active = gradioApp().getElementById("tab_images_history");
+    return ext_active && ext_active.style.display !== "none";
+}
+
 gradioApp().addEventListener("keydown", function(event) {
     // If we are not on the Image Browser Extension, dont listen for keypresses
-    var ext_active = gradioApp().getElementById("tab_images_history");
-    if (!ext_active || ext_active.style.display === "none") {
+    if (!checkImageBrowserActive()) {
         return;
     }
 

--- a/scripts/images_history.py
+++ b/scripts/images_history.py
@@ -545,7 +545,7 @@ def create_tab(tabname):
                         next_page = gr.Button('Next Page')
                         end_page = gr.Button('End Page') 
                     with gr.Column(scale=10):                            
-                        ranking = gr.Radio(value="None", choices=["1", "2", "3", "4", "5", "None"], label="ranking", interactive=True)
+                        ranking = gr.Radio(value="None", choices=["1", "2", "3", "4", "5", "None"], label="ranking", elem_id=f"{tabname}_images_ranking", interactive=True)
                         auto_next = gr.Checkbox(label="Next Image After Ranking (To be implemented)", interactive=False, visible=False)
                     history_gallery = gr.Gallery(show_label=False, elem_id=tabname + "_images_history_gallery").style(grid=opts.images_history_page_columns)
                     with gr.Row() as delete_panel:
@@ -717,7 +717,7 @@ def on_ui_tabs():
     with gr.Blocks(analytics_enabled=False) as images_history:
         with gr.Tabs(elem_id="images_history_tab") as tabs:
             for tab in tabs_list:
-                with gr.Tab(tab):
+                with gr.Tab(tab, elem_id=f"{tab}_images_history_container"):
                     with gr.Blocks(analytics_enabled=False) :
                         create_tab(tab)
         gr.Checkbox(opts.images_history_preload, elem_id="images_history_preload", visible=False)         


### PR DESCRIPTION
As above, to quickly set ranking of images the user can now just hit a number key. 0 sets it to none.

A keydown listener is created to capture input and update the html elements accordingly. To locate some of the html as well I needed to add some ids. 

Also I did some cleanup of the other key listener as well. All the logic is the exact same but previously it throws a bunch a console errors because most of the time it is null as we try to grab those elements even if we aren't on the Image Browser page, which causes undefined and null errors.

## Demo

![ranking-keypress](https://user-images.githubusercontent.com/23466035/217390441-fcc48a99-15ec-4e8c-b429-cc35aad04bee.gif)
