### PR TITLE
Removes originalTarget (only works in Firefox), instead uses composedPath() to find original target (works everywhere)

### DIFF
--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -220,10 +220,12 @@ gradioApp().addEventListener("keydown", function(event) {
     }
 
     // If the user is typing in an input field, dont listen for keypresses
+    let target;
     if (!event.composed) { // We shouldn't get here as the Shadow DOM is always active, but just in case
-        return;
+        target = event.target;
+    } else {
+        target = event.composedPath()[0];
     }
-    let target = event.composedPath()[0];
     if (!target || target.nodeName === "INPUT" || target.nodeName === "TEXTAREA") {
       return;
     }

--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -220,8 +220,11 @@ gradioApp().addEventListener("keydown", function(event) {
     }
 
     // If the user is typing in an input field, dont listen for keypresses
-    let target = event.originalTarget || event.explicitOriginalTarget;
-    if (target.nodeName === "INPUT" || target.nodeName === "TEXTAREA") {
+    if (!event.composed) { // We shouldn't get here as the Shadow DOM is always active, but just in case
+        return;
+    }
+    let target = event.composedPath()[0];
+    if (!target || target.nodeName === "INPUT" || target.nodeName === "TEXTAREA") {
       return;
     }
 


### PR DESCRIPTION
As mentioned in #32, `event.originalTarget` is only [Firefox specific](https://developer.mozilla.org/en-US/docs/Web/API/Event/explicitOriginalTarget). In hindsight I should have realised as I was reading the documentation as I first wrote my code.

Just to summarize the issue as well, because of the Shadow DOM (I believe), the `event.target` property is not set to `textarea` or `input`, but instead `gradio-app`. 

To solve this we can use [`composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath), which gives a list of all elements in the shadow tree that were involved in an event. The first element of this should be our original elem, and it does indeed seem to be as this does work for us.

I have checked in chrome as well. Additionally, at the bottom of the [`composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) it shows a compatibility chart which is all green.