### PR TITLE
Allow for user to set custom image tabs and remove preset ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and restart your stable-diffusion-webui, then you can see the new tab "Image Bro
 Please be aware that when scanning a directory for the first time, the png-cache will be built. This can take several minutes, depending on the amount of images.
 
 ## Recent updates
+- Custom tabs
 - Copy/Move to directory
 - Keybindings
 - Additional sorting and filtering by EXIF data including .txt file information

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -67,15 +67,30 @@ path_maps = {
 
 class ImageBrowserTab():
 
-    def __init__(self, name) -> None:
-        self.name = os.path.basename(name) if os.path.isdir(name) else name
-        self.path = path_maps.get(name, name)
-        self.base_tag = self.remove_invalid_html_tag_chars(self.name).lower()
-    
-    def remove_invalid_html_tag_chars(self, html_str):
+    seen_base_tags = set()
+
+    def __init__(self, name: str):
+        self.name: str = os.path.basename(name) if os.path.isdir(name) else name
+        self.path: str = path_maps.get(name, name)
+        self.base_tag: str = f"image_browser_tab_{self.get_unique_base_tag(self.remove_invalid_html_tag_chars(self.name).lower())}"
+
+    def remove_invalid_html_tag_chars(self, html_str: str) -> str:
         # Matches anything that is not a word group, or not a special character allowed in a HTML tag 
         pattern = re.compile(r'[^\w!#$%&()*+,-./:;<=>?@[\]^_`{|}~]')
         return re.sub(pattern, '', html_str)
+
+    def get_unique_base_tag(self, base_tag: str) -> str:
+        counter = 1
+        while base_tag in self.seen_base_tags:
+            match = re.search(r'_(\d+)$', base_tag)
+            if match:
+                counter = int(match.group(1)) + 1
+                base_tag = re.sub(r'_(\d+)$', f"_{counter}", base_tag)
+            else:
+                base_tag = f"{base_tag}_{counter}"
+            counter += 1
+        self.seen_base_tags.add(base_tag)
+        return base_tag
 
 tabs_list = [ImageBrowserTab(tab) for tab in tabs_list]
 

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -74,10 +74,10 @@ class ImageBrowserTab():
         self.path: str = path_maps.get(name, name)
         self.base_tag: str = f"image_browser_tab_{self.get_unique_base_tag(self.remove_invalid_html_tag_chars(self.name).lower())}"
 
-    def remove_invalid_html_tag_chars(self, html_str: str) -> str:
-        # Matches anything that is not a word group, or not a special character allowed in a HTML tag 
-        pattern = re.compile(r'[^\w!#$%&()*+,-./:;<=>?@[\]^_`{|}~]')
-        return re.sub(pattern, '', html_str)
+    def remove_invalid_html_tag_chars(self, tag: str) -> str:
+        # Matches any character that is not a letter, a digit, a hyphen, or an underscore
+        pattern = re.compile(r'[^a-zA-Z0-9\-_]')
+        return re.sub(pattern, '', tag)
 
     def get_unique_base_tag(self, base_tag: str) -> str:
         counter = 1

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -930,7 +930,7 @@ def move_setting(options, section, added):
 def on_ui_settings():
     image_browser_options = []
     # [current setting_name], [default], [label], [old setting_name]
-    active_tabs_description = f"List of active tabs (seperated by commas). Available options are {', '.join(default_tab_options)}. Custom folders are also supported by specifying their path."
+    active_tabs_description = f"List of active tabs (separated by commas). Available options are {', '.join(default_tab_options)}. Custom folders are also supported by specifying their path."
     image_browser_options.append(("image_browser_active_tabs", ", ".join(default_tab_options), active_tabs_description, None))
     image_browser_options.append(("image_browser_with_subdirs", True, "Include images in sub directories", "images_history_with_subdirs"))
     image_browser_options.append(("image_browser_preload", False, "Preload images at startup", "images_history_preload"))

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -1,4 +1,5 @@
 import gradio as gr
+import csv
 import logging
 import os
 import random
@@ -23,6 +24,9 @@ from PIL.JpegImagePlugin import JpegImageFile
 from PIL.PngImagePlugin import PngImageFile
 from pathlib import Path
 from typing import List, Tuple
+from itertools import chain
+from io import StringIO
+
 try:
     from send2trash import send2trash
     send2trash_installed = True
@@ -33,7 +37,7 @@ except ImportError:
 yappi_do = False
 favorite_tab_name = "Favorites"
 default_tab_options = ["txt2img", "img2img", "txt2img-grids", "img2img-grids", "Extras", favorite_tab_name, "Others"]
-tabs_list = opts.image_browser_active_tabs.split(", ") if hasattr(opts, "image_browser_active_tabs") else default_tab_options
+tabs_list = [tab.strip() for tab in chain.from_iterable(csv.reader(StringIO(opts.image_browser_active_tabs))) if tab] if hasattr(opts, "image_browser_active_tabs") else default_tab_options
 num_of_imgs_per_page = 0
 loads_files_num = 0
 image_ext_list = [".png", ".jpg", ".jpeg", ".bmp", ".gif", ".webp"]
@@ -902,7 +906,7 @@ def move_setting(options, section, added):
 def on_ui_settings():
     image_browser_options = []
     # [current setting_name], [default], [label], [old setting_name]
-    active_tabs_description = f"List of active tabs. Available options are {', '.join(default_tab_options)}. Custom folders are also supported by specifying their path."
+    active_tabs_description = f"List of active tabs (seperated by commas). Available options are {', '.join(default_tab_options)}. Custom folders are also supported by specifying their path."
     image_browser_options.append(("image_browser_active_tabs", ", ".join(default_tab_options), active_tabs_description, None))
     image_browser_options.append(("image_browser_with_subdirs", True, "Include images in sub directories", "images_history_with_subdirs"))
     image_browser_options.append(("image_browser_preload", False, "Preload images at startup", "images_history_preload"))


### PR DESCRIPTION
Closes #50.

Adds a new setting `image_browser_active_tabs` which controls which tabs are active. We can also insert our own paths in here as well, and it will just work, which is great.

![image](https://user-images.githubusercontent.com/23466035/221116207-293ac728-c57b-4428-b4af-10e04f70c6d8.png)
![image](https://user-images.githubusercontent.com/23466035/221116254-7d8c0a1d-c46c-4ad3-a033-2b3957468c46.png)

### Some Notes
- It does work with folders with spaces
- I do not know if it works with symlinks. I don't know if this would be affected by it, but I often hear issues about symlinks and gradio. I don't think there should be any issues though.
- I also don't know if this works on MacOS and Linux, but I am only using the default python path `os.path` functions so I think that should be fine.
- Renamed `custom_dir` to `others_dir`, previously `custom_dir` was only set to True if it was the `Others` tab, so it makes more sense to call it that and actual custom directories don't follow that path.

### Slight Fix

Uses `[x.strip() for x in chain.from_iterable(csv.reader(StringIO(vals)))]` comprehension from webui, also as described in https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7954. This is pretty comprehensive, and should handle quotes, embedded commas, and pretty much everything I believe in case users have weird folder names.

All imports are added are from the standard python library, so no issues there.