### PR TITLE
Fixed issue where files were given rankings incorrectly.

### DIFF
--- a/scripts/wib/wib_db.py
+++ b/scripts/wib/wib_db.py
@@ -1,10 +1,10 @@
+import datetime
 import json
 import os
 import sqlite3
 from modules import scripts
-import datetime
 
-version = 3
+version = 4
 
 path_recorder_file = os.path.join(scripts.basedir(), "path_recorder.txt")
 aes_cache_file = os.path.join(scripts.basedir(), "aes_scores.json")
@@ -341,30 +341,53 @@ def migrate_ranking_dirs(cursor, db_version):
 
     return
 
+def get_c_time(file):
+    c_time = datetime.datetime.fromtimestamp(os.path.getctime(file)).strftime('%Y-%m-%d %H:%M:%S')
+    return c_time
+
+def migrate_ranking_c_time(cursor):
+    cursor.execute('''
+    SELECT file
+    FROM ranking
+    ''')
+    for (file,) in cursor.fetchall():
+        if os.path.exists(file):
+            c_time = get_c_time(file)
+            cursor.execute('''
+            UPDATE ranking
+            SET created = ?
+            WHERE file = ?
+            ''', (c_time, file))
+    
+    return
+
 def check():
     if not os.path.exists(db_file):
-        print("Image Browser: Creating database")
         conn, cursor = transaction_begin()
+        print("Image Browser: Creating database")
         create_db(cursor)
         update_db_data(cursor, "version", version)
         migrate_path_recorder(cursor)
         migrate_exif_data(cursor)
         migrate_ranking(cursor)
+        migrate_ranking_c_time(cursor)
         transaction_end(conn, cursor)
         print("Image Browser: Database created")
     db_version = get_version()
+    conn, cursor = transaction_begin()
     if db_version[0] <= "2":
         # version 1 database had mixed path notations, changed them all to abspath
         # version 2 database still had mixed path notations, because of windows short name, changed them all to realpath
         print(f"Image Browser: Upgrading database from version {db_version[0]} to version {version}")
-        conn, cursor = transaction_begin()
-        update_db_data(cursor, "version", version)
         migrate_path_recorder_dirs(cursor)
         migrate_exif_data_dirs(cursor)
         migrate_ranking_dirs(cursor, db_version[0])
-        transaction_end(conn, cursor)
+    if db_version[0] <= "3":
+        migrate_ranking_c_time(cursor)
+        update_db_data(cursor, "version", version)
         print(f"Image Browser: Database upgraded from version {db_version[0]} to version {version}")
-
+    transaction_end(conn, cursor)
+        
     return version
 
 def load_path_recorder():
@@ -378,19 +401,19 @@ def load_path_recorder():
 
     return path_recorder
 
-def select_ranking(filename):
+def select_ranking(file):
     conn, cursor = transaction_begin()
     cursor.execute('''
     SELECT ranking
     FROM ranking
     WHERE file = ?
-    ''', (filename,))
+    ''', (file,))
     ranking_value = cursor.fetchone()
     
     # if ranking not found search again, without path (moved?)
     if ranking_value is None:
-        c_time = datetime.datetime.fromtimestamp(os.path.getctime(filename)).strftime('%Y-%m-%d %H:%M:%S')
-        name = os.path.basename(filename)
+        c_time = get_c_time(file)
+        name = os.path.basename(file)
         cursor.execute('''
         SELECT ranking
         FROM ranking
@@ -411,7 +434,7 @@ def select_ranking(filename):
             cursor.execute('''
             INSERT INTO ranking (file, name, ranking, created)
             VALUES (?, ?, ?, ?)
-            ''', (filename, name, insert_ranking, c_time))
+            ''', (file, name, insert_ranking, c_time))
     
     if ranking_value is None:
         return_ranking = "None"
@@ -425,7 +448,7 @@ def update_ranking(file, ranking):
     name = os.path.basename(file)
     with sqlite3.connect(db_file, timeout=timeout) as conn:
         cursor = conn.cursor()
-        c_time = datetime.datetime.fromtimestamp(os.path.getctime(file)).strftime('%Y-%m-%d %H:%M:%S')
+        c_time = get_c_time(file)
         if ranking == "None":
                 cursor.execute('''
                 DELETE FROM ranking


### PR DESCRIPTION
In the wib.sqlite3 database the image browser automatically ranks any new images with the same file name the same when i inspect them in the UI (through pressing the image directly or filtering by rank)


Steps to reproduce:
* Create two files with the same name.
* Rate one of them
* Look at the other or filter by any rank
* Two entries have appeared in the wib database with the rank of the first file. Same name and unique file column.


The bug is with the insertion starting at line 390 assumes I've moved the file because the name exists in the database but the search failed on the file column.
https://github.com/AlUlkesh/stable-diffusion-webui-images-browser/blob/e508543da1accc323953e8e5c08083f15ba68a2b/scripts/wib/wib_db.py#L390-L404

The reason I'm exposed to this bug is because I use https://github.com/mcmonkeyprojects/sd-infinity-grid-generator-script to generate images and I would like to filter them using the image browser. It creates a folder structure for navigating its grid and names the image files are the same for a single axis value. Perhaps this is not a common usecase.

Currently when files are moved old database entries are left in the database. I added a delete to deal with that
https://github.com/MrSnowman/stable-diffusion-webui-images-browser/blob/b85a2b9f9c186b1606cdb30cbc4e9cd5c5c67408/scripts/wib/wib_db.py#L401-L410


I'm unsure about the proper way to migrate the database, so I won't do that but I ran this script for my own database:
```python
import sqlite3
import os
import datetime

with sqlite3.connect("wib.sqlite3") as conn:
    results=conn.execute("SELECT file from ranking;").fetchall()
    
    for res in results:
        (file,) = res
        if os.path.isfile(file):
            c_time = datetime.datetime.fromtimestamp(os.path.getctime(file)).strftime('%Y-%m-%d %H:%M:%S')
            conn.execute('''
                        UPDATE
                        ranking SET created = ?
                        WHERE file = ?
                        ''', (c_time, file))
```

