### PR TITLE
Add option: "Use optimized images in the thumbnail interface"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and restart your stable-diffusion-webui, then you can see the new tab "Image Bro
 Please be aware that when scanning a directory for the first time, the png-cache will be built. This can take several minutes, depending on the amount of images.
 
 ## Recent updates
+- Optimized images in the thumbnail interface
 - Send to ControlNet
 - Hidable UI components
 - Send to openOutpaint

--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -65,18 +65,66 @@ function image_browser_get_parent_by_tagname(item, tagname) {
     return parent
 }
 
-async function image_browser_get_current_img(tab_base_tag, img_index, page_index, filenames, turn_page_switch) {
+function image_browser_run_after_preview_load(tab_base_tag, func) {
+    ob = new MutationObserver(async (mutationList, observer) => {
+        elem = mutationList[0].target
+        if (elem.classList.contains("hide")) { 
+            func()
+            observer.disconnect()
+        }
+    })
+    ob.observe(
+        gradioApp().querySelectorAll(`#${tab_base_tag}_image_browser_gallery .svelte-gjihhp`)[0],
+        { attributes: true }
+    )
+}
+
+async function image_browser_get_current_img(tab_base_tag, img_index, page_index, filenames, turn_page_switch, image_gallery) {
     await image_browser_lock("image_browser_get_current_img")
     img_index = gradioApp().getElementById(tab_base_tag + '_image_browser_set_index').getAttribute("img_index")
+    image_browser_hide_loading_animation(true)
     gradioApp().dispatchEvent(new Event("image_browser_get_current_img"))
+    image_browser_run_after_preview_load(tab_base_tag,() => image_browser_hide_loading_animation(false))
     await image_browser_unlock()
     return [
         tab_base_tag,
         img_index,
         page_index,
 		filenames,
-		turn_page_switch
+        turn_page_switch,
+        image_gallery
     ]
+}
+
+function image_browser_hide_loading_animation(hidden) {
+    if (hidden === true) {
+        gradioApp().querySelectorAll("div[id^='image_browser_tab'][id$='image_browser_gallery']:not(.hide_loading)").forEach((elem) => {
+            elem.classList.add("hide_loading")
+        })
+    } else { 
+        gradioApp().querySelectorAll("div[id^='image_browser_tab'][id$='image_browser_gallery'].hide_loading").forEach((elem) => {
+            elem.classList.remove("hide_loading")
+        })
+    }
+}
+
+async function image_browser_refresh_preview(tab_base_tag) { 
+    // Close preview first
+    await image_browser_delay(500)
+    const close_btn = gradioApp().querySelector('.preview button:not(.thumbnail-item)')
+    if (close_btn === null) { 
+        return
+    }
+    close_btn.click()
+    // Open preview again
+    const gallery = gradioApp().querySelector(`#${tab_base_tag}_image_browser`)
+    const set_btn = gallery.querySelector(".image_browser_set_index")
+    const curr_idx = set_btn.getAttribute("img_index")
+    image_browser_run_after_preview_load(tab_base_tag, () => { 
+        const gallery_items = gallery.querySelectorAll(galleryItemNameDot)
+        const curr_image = gallery_items[curr_idx]
+        curr_image.click()
+    })
 }
 
 async function image_browser_select_image(tab_base_tag, img_index) {

--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -368,7 +368,7 @@ function image_browser_start() {
 function image_browser_current_tab() {
     const tabs = gradioApp().getElementById("image_browser_tabs_container").querySelectorAll('[id$="_image_browser_container"]')
     const tab_base_tags = gradioApp().getElementById("image_browser_tab_base_tags_list")
-    const image_browser_tab_base_tags_list = tab_base_tags.querySelector("textarea").value.split(",")
+    const image_browser_tab_base_tags_list = tab_base_tags.querySelector("textarea").value.split(",").sort((a, b) => b.length - a.length);
     for (const element of tabs) {
       if (element.style.display === "block") {
         const id = element.id

--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -108,18 +108,29 @@ function image_browser_hide_loading_animation(hidden) {
     }
 }
 
-async function image_browser_refresh_preview(tab_base_tag) { 
-    // Close preview first
-    await image_browser_delay(500)
-    const close_btn = gradioApp().querySelector('.preview button:not(.thumbnail-item)')
-    if (close_btn === null) { 
-        return
-    }
-    close_btn.click()
-    // Open preview again
+async function image_browser_refresh_current_page_preview(wait_time = 200) { 
+    await image_browser_delay(wait_time)
+    const preview_div = gradioApp().querySelector('.preview')
+    if (preview_div === null) return
+    const tab_base_tag = image_browser_current_tab()
+    const gallery = gradioApp().querySelector(`#${tab_base_tag}_image_browser`)
+    const set_btn = gallery.querySelector(".image_browser_set_index")
+    const curr_idx = parseInt(set_btn.getAttribute("img_index"))
+    // no loading animation, so click immediately
+    const gallery_items = gallery.querySelectorAll(galleryItemNameDot)
+    const curr_image = gallery_items[curr_idx]
+    curr_image.click()
+}
+
+async function image_browser_refresh_preview(wait_time = 200) { 
+    await image_browser_delay(wait_time)
+    const preview_div = gradioApp().querySelector('.preview')
+    if (preview_div === null) return
+    const tab_base_tag = image_browser_current_tab()
     const gallery = gradioApp().querySelector(`#${tab_base_tag}_image_browser`)
     const set_btn = gallery.querySelector(".image_browser_set_index")
     const curr_idx = set_btn.getAttribute("img_index")
+    // wait for page loading...
     image_browser_run_after_preview_load(tab_base_tag, () => { 
         const gallery_items = gallery.querySelectorAll(galleryItemNameDot)
         const curr_image = gallery_items[curr_idx]
@@ -449,9 +460,25 @@ function image_browser_keydown() {
             prevBtn.dispatchEvent(new Event("click"))
         }
 
+        if (event.code == "ArrowLeft" && modifiers_none) {
+            const tab_base_tag = image_browser_current_tab()
+            const set_btn = gradioApp().querySelector(`#${tab_base_tag}_image_browser .image_browser_set_index`)
+            const curr_idx = parseInt(set_btn.getAttribute("img_index"))
+            set_btn.setAttribute("img_index", curr_idx - 1)
+            image_browser_refresh_current_page_preview()
+        }
+        
         if (event.code == "ArrowRight" && modifiers_pressed) {
             const nextBtn = gradioApp().getElementById(tab_base_tag + "_image_browser_next_page")
             nextBtn.dispatchEvent(new Event("click"))
+        }
+
+        if (event.code == "ArrowRight" && modifiers_none) {
+            const tab_base_tag = image_browser_current_tab()
+            const set_btn = gradioApp().querySelector(`#${tab_base_tag}_image_browser .image_browser_set_index`)
+            const curr_idx = parseInt(set_btn.getAttribute("img_index"))
+            set_btn.setAttribute("img_index", curr_idx + 1)
+            image_browser_refresh_current_page_preview()
         }
     })
 }

--- a/javascript/image_browser.js
+++ b/javascript/image_browser.js
@@ -368,7 +368,7 @@ function image_browser_start() {
 function image_browser_current_tab() {
     const tabs = gradioApp().getElementById("image_browser_tabs_container").querySelectorAll('[id$="_image_browser_container"]')
     const tab_base_tags = gradioApp().getElementById("image_browser_tab_base_tags_list")
-    const image_browser_tab_base_tags_list = tab_base_tags.querySelector("textarea").value.split(",").sort((a, b) => b.length - a.length);
+    const image_browser_tab_base_tags_list = tab_base_tags.querySelector("textarea").value.split(",").sort((a, b) => b.length - a.length)
     for (const element of tabs) {
       if (element.style.display === "block") {
         const id = element.id

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -1229,7 +1229,6 @@ def create_tab(tab: ImageBrowserTab, current_gr_tab: gr.Tab):
     img_file_name.change(fn=lambda : "", inputs=None, outputs=[collected_warning])
     img_file_name.change(get_ranking, inputs=img_file_name, outputs=ranking)
    
-    # hidden.change(fn=lambda h:h,_js="update_preivew_state",inputs=[hidden], outputs=None)
     hidden.change(fn=run_pnginfo, inputs=[hidden, img_path, img_file_name], outputs=[info1, img_file_info, info2, image_browser_prompt, image_browser_neg_prompt])
     
     #ranking

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -757,6 +757,7 @@ def get_image_thumbnail(image_list):
             thumbnail = image.crop((left, top, right, bottom))
             thumbnail.thumbnail((opts.image_browser_thumbnail_size, opts.image_browser_thumbnail_size))
         except OSError:
+            # If PIL cannot open the image, use the original path
             thumbnail_list.append(image_path)
         else:
             thumbnail_list.append(thumbnail)
@@ -1146,9 +1147,13 @@ def create_tab(tab: ImageBrowserTab, current_gr_tab: gr.Tab):
         favorites_btn.click(save_image, inputs=[img_file_name, filenames, page_index, turn_page_switch, favorites_path], outputs=[collected_warning, filenames, page_index, turn_page_switch])
         img_file_name.change(fn=update_move_text, inputs=[favorites_btn, to_dir_btn], outputs=[favorites_btn, to_dir_btn])
     to_dir_btn.click(save_image, inputs=[img_file_name, filenames, page_index, turn_page_switch, to_dir_path], outputs=[collected_warning, filenames, page_index, turn_page_switch])
-    #refresh preview when turning page
-    for btn in (first_page, next_page, prev_page, end_page):
-        btn.click(None,_js="image_browser_refresh_preview", inputs=[tab_base_tag_box], outputs=None)
+    #refresh preview when page is updated
+    for btn in (first_page, next_page, prev_page, end_page, refresh_index_button, sort_order, ):
+        btn.click(None,_js="image_browser_refresh_preview", inputs=None, outputs=None)
+    for component in (sort_by, ranking_filter):
+        component.change(None,_js="image_browser_refresh_preview", inputs=None, outputs=None)
+    for component in (filename_keyword_search, exif_keyword_search, aes_filter_min, aes_filter_max, page_index):
+        component.submit(None,_js="image_browser_refresh_preview", inputs=None, outputs=None)
     #turn page
     first_page.click(lambda s:(1, -s) , inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
     next_page.click(lambda p, s: (p + 1, -s), inputs=[page_index, turn_page_switch], outputs=[page_index, turn_page_switch])

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -747,15 +747,19 @@ def get_all_images(dir_name, sort_by, sort_order, keyword, tab_base_tag_box, img
 def get_image_thumbnail(image_list):
     thumbnail_list = []
     for image_path in image_list:
-        image = Image.open(image_path)
-        width, height = image.size
-        left = (width - min(width, height)) / 2
-        top = (height - min(width, height)) / 2
-        right = (width + min(width, height)) / 2
-        bottom = (height + min(width, height)) / 2
-        image = image.crop((left, top, right, bottom))
-        image.thumbnail((opts.image_browser_thumbnail_size, opts.image_browser_thumbnail_size))
-        thumbnail_list.append(image)
+        try:
+            image = Image.open(image_path)
+            width, height = image.size
+            left = (width - min(width, height)) / 2
+            top = (height - min(width, height)) / 2
+            right = (width + min(width, height)) / 2
+            bottom = (height + min(width, height)) / 2
+            thumbnail = image.crop((left, top, right, bottom))
+            thumbnail.thumbnail((opts.image_browser_thumbnail_size, opts.image_browser_thumbnail_size))
+        except OSError:
+            thumbnail_list.append(image_path)
+        else:
+            thumbnail_list.append(thumbnail)
     return thumbnail_list
 
 def get_image_page(img_path, page_index, filenames, keyword, sort_by, sort_order, tab_base_tag_box, img_path_depth, ranking_filter, aes_filter_min, aes_filter_max, exif_keyword, negative_prompt_search, use_regex, case_sensitive):

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -744,6 +744,20 @@ def get_all_images(dir_name, sort_by, sort_order, keyword, tab_base_tag_box, img
             filenames = [finfo for finfo in fileinfos]
     return filenames
 
+def get_image_thumbnail(image_list):
+    thumbnail_list = []
+    for image_path in image_list:
+        image = Image.open(image_path)
+        width, height = image.size
+        left = (width - min(width, height)) / 2
+        top = (height - min(width, height)) / 2
+        right = (width + min(width, height)) / 2
+        bottom = (height + min(width, height)) / 2
+        image = image.crop((left, top, right, bottom))
+        image.thumbnail((opts.image_browser_thumbnail_size, opts.image_browser_thumbnail_size))
+        thumbnail_list.append(image)
+    return thumbnail_list
+
 def get_image_page(img_path, page_index, filenames, keyword, sort_by, sort_order, tab_base_tag_box, img_path_depth, ranking_filter, aes_filter_min, aes_filter_max, exif_keyword, negative_prompt_search, use_regex, case_sensitive):
     if img_path == "":
         return [], page_index, [],  "", "",  "", 0, "", None, ""
@@ -762,7 +776,12 @@ def get_image_page(img_path, page_index, filenames, keyword, sort_by, sort_order
     page_index = max_page_index if page_index > max_page_index else page_index
     idx_frm = (page_index - 1) * num_of_imgs_per_page
     image_list = filenames[idx_frm:idx_frm + num_of_imgs_per_page]
-    
+
+    if opts.image_browser_use_thumbnail:
+        thumbnail_list = get_image_thumbnail(image_list)
+    else:
+        thumbnail_list = image_list
+
     visible_num = num_of_imgs_per_page if  idx_frm + num_of_imgs_per_page < length else length % num_of_imgs_per_page 
     visible_num = num_of_imgs_per_page if visible_num == 0 else visible_num
 
@@ -770,13 +789,13 @@ def get_image_page(img_path, page_index, filenames, keyword, sort_by, sort_order
     load_info += f"{length} images in this directory, divided into {int((length + 1) // num_of_imgs_per_page  + 1)} pages"
     load_info += "</div>"
     
-    return filenames, gr.update(value=page_index, label=f"Page Index ({page_index}/{max_page_index})"), image_list,  "", "",  "", visible_num, load_info, None, json.dumps(image_list)
+    return filenames, gr.update(value=page_index, label=f"Page Index ({page_index}/{max_page_index})"), thumbnail_list,  "", "",  "", visible_num, load_info, None, json.dumps(image_list)
 
 def get_current_file(tab_base_tag_box, num, page_index, filenames):
     file = filenames[int(num) + int((page_index - 1) * num_of_imgs_per_page)]
     return file
     
-def show_image_info(tab_base_tag_box, num, page_index, filenames, turn_page_switch):
+def show_image_info(tab_base_tag_box, num, page_index, filenames, turn_page_switch, image_gallery):
     logger.debug(f"tab_base_tag_box, num, page_index, len(filenames), num_of_imgs_per_page: {tab_base_tag_box}, {num}, {page_index}, {len(filenames)}, {num_of_imgs_per_page}")
     if len(filenames) == 0:
         # This should only happen if webui was stopped and started again and the user clicks on one of the still displayed images.
@@ -802,7 +821,12 @@ def show_image_info(tab_base_tag_box, num, page_index, filenames, turn_page_swit
             except UnidentifiedImageError as e:
                 info = ""
                 logger.warning(f"UnidentifiedImageError: {e}")
-    return file, tm, num, file, turn_page_switch, info
+            if opts.image_browser_use_thumbnail:
+                image_gallery = [image['name'] for image in image_gallery]
+                image_gallery[int(num)] = filenames[file_num]
+            else:
+                image_gallery = gr.update()
+    return file, tm, num, file, turn_page_switch, info, image_gallery
 
 def change_dir(img_dir, path_recorder, load_switch, img_path_browser, img_path_depth, img_path):
     warning = None
@@ -1118,12 +1142,14 @@ def create_tab(tab: ImageBrowserTab, current_gr_tab: gr.Tab):
         favorites_btn.click(save_image, inputs=[img_file_name, filenames, page_index, turn_page_switch, favorites_path], outputs=[collected_warning, filenames, page_index, turn_page_switch])
         img_file_name.change(fn=update_move_text, inputs=[favorites_btn, to_dir_btn], outputs=[favorites_btn, to_dir_btn])
     to_dir_btn.click(save_image, inputs=[img_file_name, filenames, page_index, turn_page_switch, to_dir_path], outputs=[collected_warning, filenames, page_index, turn_page_switch])
-
+    #refresh preview when turning page
+    for btn in (first_page, next_page, prev_page, end_page):
+        btn.click(None,_js="image_browser_refresh_preview", inputs=[tab_base_tag_box], outputs=None)
     #turn page
     first_page.click(lambda s:(1, -s) , inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
     next_page.click(lambda p, s: (p + 1, -s), inputs=[page_index, turn_page_switch], outputs=[page_index, turn_page_switch])
     prev_page.click(lambda p, s: (p - 1, -s), inputs=[page_index, turn_page_switch], outputs=[page_index, turn_page_switch])
-    end_page.click(lambda s: (-1, -s), inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])    
+    end_page.click(lambda s: (-1, -s), inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
     load_switch.change(lambda s:(1, -s), inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
     filename_keyword_search.submit(lambda s:(1, -s), inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
     exif_keyword_search.submit(lambda s:(1, -s), inputs=[turn_page_switch], outputs=[page_index, turn_page_switch])
@@ -1198,12 +1224,12 @@ def create_tab(tab: ImageBrowserTab, current_gr_tab: gr.Tab):
     )
 
     # other functions
-    set_index.click(show_image_info, _js="image_browser_get_current_img", inputs=[tab_base_tag_box, image_index, page_index, filenames, turn_page_switch], outputs=[img_file_name, img_file_time, image_index, hidden, turn_page_switch, img_file_info_add])
+    set_index.click(show_image_info, _js="image_browser_get_current_img", inputs=[tab_base_tag_box, image_index, page_index, filenames, turn_page_switch, image_gallery], outputs=[img_file_name, img_file_time, image_index, hidden, turn_page_switch, img_file_info_add, image_gallery])
     set_index.click(fn=lambda:(gr.update(visible=delete_panel not in override_hidden), gr.update(visible=button_panel not in override_hidden), gr.update(visible=ranking_panel not in override_hidden), gr.update(visible=to_dir_panel not in override_hidden), gr.update(visible=info_add_panel not in override_hidden)), inputs=None, outputs=hide_on_thumbnail_view)
     img_file_name.change(fn=lambda : "", inputs=None, outputs=[collected_warning])
     img_file_name.change(get_ranking, inputs=img_file_name, outputs=ranking)
-
    
+    # hidden.change(fn=lambda h:h,_js="update_preivew_state",inputs=[hidden], outputs=None)
     hidden.change(fn=run_pnginfo, inputs=[hidden, img_path, img_file_name], outputs=[info1, img_file_info, info2, image_browser_prompt, image_browser_neg_prompt])
     
     #ranking
@@ -1352,6 +1378,8 @@ def on_ui_settings():
         ("image_browser_page_columns", "images_history_page_columns", 6, "Number of columns on the page"),
         ("image_browser_page_rows", "images_history_page_rows", 6, "Number of rows on the page"),
         ("image_browser_pages_perload", "images_history_pages_perload", 20, "Minimum number of pages per load"),
+        ("image_browser_use_thumbnail", None, True, "Use optimized images in the thumbnail interface"),
+        ("image_browser_thumbnail_size", None, 200, "Size of the thumbnails (px)"),
     ]
 
     section = ('image-browser', "Image Browser")

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -1386,7 +1386,7 @@ def on_ui_settings():
         ("image_browser_page_columns", "images_history_page_columns", 6, "Number of columns on the page"),
         ("image_browser_page_rows", "images_history_page_rows", 6, "Number of rows on the page"),
         ("image_browser_pages_perload", "images_history_pages_perload", 20, "Minimum number of pages per load"),
-        ("image_browser_use_thumbnail", None, True, "Use optimized images in the thumbnail interface"),
+        ("image_browser_use_thumbnail", None, False, "Use optimized images in the thumbnail interface (significantly reduces the amount of data transferred)"),
         ("image_browser_thumbnail_size", None, 200, "Size of the thumbnails (px)"),
     ]
 

--- a/style.css
+++ b/style.css
@@ -1,3 +1,7 @@
 .thumbnails.svelte-1tkea93.svelte-1tkea93 {
   justify-content: initial;
 }
+
+div[id^="image_browser_tab"][id$="image_browser_gallery"].hide_loading > .svelte-gjihhp {
+  display: none;
+}


### PR DESCRIPTION
Use optimized images rendering thumbnail interface. 

The original implementation always loads the original image, even if the height and width of the thumbnail are less than 200 px. This not only becomes a bandwidth bottleneck for cloud deployment but also causes the browser to consume more RAM. So I modified the code to only load low-resolution images in the thumbnail interface until the user clicks on the thumbnail for detailed preview, and then load the original image. For grids, such optimization can reduce the amount of data transferred by more than 90%.

By the way, I seem to have also fixed the issue where components in `hide_on_thumbnail_view` were not displaying properly when changing pages with an image selected.

Before：
![before](https://user-images.githubusercontent.com/51732678/228589341-cdf3081b-c0a4-4b15-a1fd-e2e956a95a4b.gif)

After：
![after](https://user-images.githubusercontent.com/51732678/228593154-f4eede77-03f4-44f1-a101-dcf41e5e02ab.gif)


