### PR TITLE
Fix check for imagereward

### DIFF
--- a/install.py
+++ b/install.py
@@ -3,5 +3,5 @@ import launch
 if not launch.is_installed("send2trash"):
     launch.run_pip("install Send2Trash", "Send2Trash requirement for image browser")
 
-if not launch.is_installed("image-reward"):
+if not launch.is_installed("ImageReward"):
     launch.run_pip("install image-reward", "ImageReward requirement for image browser")


### PR DESCRIPTION
`launch.is_installed()` takes a module name, not a package name.
https://docs.python.org/3.10/library/importlib.html#importlib.util.find_spec

Imagereward was being reinstalled every time.