### PR TITLE
Update style.css to fix safari devices to workaround gradio issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,3 +13,11 @@ div[id^="image_browser_tab"][id$="image_browser_gallery"].hide_loading > .svelte
 .image_browser_gallery img {
   object-fit: scale-down !important;
 }
+
+/* Workaround until gradio version is updated to a version that fixes it
+   see https://github.com/gradio-app/gradio/issues/1590
+*/
+.thumbnail-item > img {
+  width: auto !important;
+  height: auto !important;
+}


### PR DESCRIPTION
The Gradio version used by auto1111 appears to have a strange issue related to safari, although it was fixed it seems to have returned.  

This workaround appears to resolve it.  Tested on ios and mac safari latest.

Closes #117 

See also

https://github.com/gradio-app/gradio/issues/1590
https://github.com/gradio-app/gradio/pull/2265
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/232
https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/905#issuecomment-1281126394
