### PR TITLE
Added All tab plus minor bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and restart your stable-diffusion-webui, then you can see the new tab "Image Bro
 Please be aware that when scanning a directory for the first time, the png-cache will be built. This can take several minutes, depending on the amount of images.
 
 ## Recent updates
+- "All"-tab showing all the images from all tabs combined
 - Image Reward scoring
 - Size tooltip for thumbnails
 - Optimized images in the thumbnail interface

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -96,7 +96,8 @@ def check_image_browser_active_tabs():
             shared.opts.save(shared.config_filename)
 
 favorite_tab_name = "Favorites"
-default_tab_options = ["txt2img", "img2img", "txt2img-grids", "img2img-grids", "Extras", favorite_tab_name, "Others"]
+default_output_path = "outputs"
+default_tab_options = ["All", "txt2img", "img2img", "txt2img-grids", "img2img-grids", "Extras", favorite_tab_name, "Others"]
 check_image_browser_active_tabs()
 tabs_list = [tab.strip() for tab in chain.from_iterable(csv.reader(StringIO(opts.image_browser_active_tabs))) if tab] if hasattr(opts, "image_browser_active_tabs") else default_tab_options
 try:
@@ -106,6 +107,7 @@ except AttributeError:
     tabs_list.append("Maintenance")  # mandatory tab
 
 path_maps = {
+    "All": opts.outdir_samples or default_output_path,
     "txt2img": opts.outdir_samples or opts.outdir_txt2img_samples,
     "img2img": opts.outdir_samples or opts.outdir_img2img_samples,
     "txt2img-grids": opts.outdir_grids or opts.outdir_txt2img_grids,
@@ -113,6 +115,7 @@ path_maps = {
     "Extras": opts.outdir_samples or opts.outdir_extras_samples,
     favorite_tab_name: opts.outdir_save
 }
+
 
 class ImageBrowserTab():
 

--- a/scripts/image_browser.py
+++ b/scripts/image_browser.py
@@ -85,23 +85,25 @@ js_dummy_return = None
 log_file = os.path.join(scripts.basedir(), "image_browser.log")
 image_reward_model = None
 
-def check_image_browser_active_tabs():
-    # Check if Maintenance tab has been added to settings in addition to as a mandatory tab. If so, remove.
-    if hasattr(opts, "image_browser_active_tabs"):
-        active_tabs_no_maint = re.sub(r",\s*Maintenance", "", opts.image_browser_active_tabs)
-        if len(active_tabs_no_maint) != len(opts.image_browser_active_tabs):
-            shared.opts.__setattr__("image_browser_active_tabs", active_tabs_no_maint)
-            shared.opts.save(shared.config_filename)
+db_version = wib_db.check()
 
 favorite_tab_name = "Favorites"
-default_tab_options = ["All", "txt2img", "img2img", "txt2img-grids", "img2img-grids", "Extras", favorite_tab_name, "Others"]
+default_tab_options = ["txt2img", "img2img", "txt2img-grids", "img2img-grids", "Extras", favorite_tab_name, "Others", "All", "Maintenance"]
+
+def check_image_browser_active_tabs():
+    last_default_tab = wib_db.get_last_default_tab()
+    if last_default_tab[0] == "Others":
+        # New tabs don't exist yet in image_browser_active_tabs, add them
+        conn, cursor = wib_db.transaction_begin()
+        wib_db.update_db_data(cursor, "last_default_tab", "Maintenance")
+        wib_db.transaction_end(conn, cursor)
+        if hasattr(opts, "image_browser_active_tabs"):
+            active_and_new_tabs = f"{opts.image_browser_active_tabs}, All, Maintenance"
+            shared.opts.__setattr__("image_browser_active_tabs", active_and_new_tabs)
+            shared.opts.save(shared.config_filename)
+
 check_image_browser_active_tabs()
 tabs_list = [tab.strip() for tab in chain.from_iterable(csv.reader(StringIO(opts.image_browser_active_tabs))) if tab] if hasattr(opts, "image_browser_active_tabs") and opts.image_browser_active_tabs != ""  else default_tab_options
-try:
-    if opts.image_browser_enable_maint:
-        tabs_list.append("Maintenance")  # mandatory tab
-except AttributeError:
-    tabs_list.append("Maintenance")  # mandatory tab
 
 path_maps = {
     "txt2img": opts.outdir_samples or opts.outdir_txt2img_samples,
@@ -230,6 +232,7 @@ def restart_debug(parameter):
             logger.debug(f.read())
         logger.debug(os.path.realpath(__file__))
         logger.debug([str(tab) for tab in tabs_list])
+        logger.debug(f"db_version: {db_version}")
     maint_last_msg = "Debug restarted"
 
     return parameter, maint_last_msg
@@ -1107,8 +1110,6 @@ def create_tab(tab: ImageBrowserTab, current_gr_tab: gr.Tab):
     path_recorder_unformatted = []
     
     if init:
-        db_version = wib_db.check()
-        logger.debug(f"db_version: {db_version}")
         exif_cache = wib_db.load_exif_data(exif_cache)
         aes_cache = wib_db.load_exif_data_by_key(aes_cache, "aesthetic_score", "Score")
         image_reward_cache = wib_db.load_exif_data_by_key(image_reward_cache, "ImageRewardScore", "ImageRewardScore")
@@ -1702,7 +1703,6 @@ def on_ui_settings():
         ("image_browser_scan_exif", "images_scan_exif", True, "Scan Exif-/.txt-data (initially slower, but required for many features to work)"),
         ("image_browser_mod_shift", None, False, "Change CTRL keybindings to SHIFT"),
         ("image_browser_mod_ctrl_shift", None, False, "or to CTRL+SHIFT"),
-        ("image_browser_enable_maint", None, True, "Enable Maintenance tab"),
         ("image_browser_ranking_pnginfo", None, False, "Save ranking in image's pnginfo"),
         ("image_browser_page_columns", "images_history_page_columns", 6, "Number of columns on the page"),
         ("image_browser_page_rows", "images_history_page_rows", 6, "Number of rows on the page"),

--- a/scripts/wib/wib_db.py
+++ b/scripts/wib/wib_db.py
@@ -5,7 +5,7 @@ import sqlite3
 from modules import scripts
 from PIL import Image
 
-version = 6
+version = 7
 
 path_recorder_file = os.path.join(scripts.basedir(), "path_recorder.txt")
 aes_cache_file = os.path.join(scripts.basedir(), "aes_scores.json")
@@ -302,6 +302,18 @@ def get_version():
     
     return db_version
 
+def get_last_default_tab():
+    with sqlite3.connect(db_file, timeout=timeout) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+        SELECT value
+        FROM db_data
+        WHERE key = 'last_default_tab'
+        ''',)
+        last_default_tab = cursor.fetchone()
+    
+    return last_default_tab
+
 def migrate_path_recorder_dirs(cursor):
     cursor.execute('''
     SELECT path, path_display
@@ -434,6 +446,8 @@ def check():
         migrate_filehash(cursor, db_version[0])
     if db_version[0] <= "5":
         migrate_work_files(cursor)
+    if db_version[0] <= "6":
+        update_db_data(cursor, "last_default_tab", "Others")
         update_db_data(cursor, "version", version)
         print(f"Image Browser: Database upgraded from version {db_version[0]} to version {version}")
     transaction_end(conn, cursor)

--- a/style.css
+++ b/style.css
@@ -14,6 +14,21 @@ div[id^="image_browser_tab"][id$="image_browser_gallery"].hide_loading > .svelte
   object-fit: scale-down !important;
 }
 
+/* hack to fix the alignment of the page index, refresh, and delete buttons*/
+div[id$='control_image_browser_page_index'] {
+  margin-top: -20px !important;
+  margin-left: 10px !important;
+  display: grid;
+  justify-content: end;
+}
+button[id$='_control_image_browser_refresh_index']{
+  align-self: start !important;
+  height: 2em !important;
+}
+button[id$='_image_browser_del_img_btn'] {
+  margin-top: 22px !important;
+}
+
 /* Workaround until gradio version is updated to a version that fixes it
    see https://github.com/gradio-app/gradio/issues/1590
 */


### PR DESCRIPTION
Added an "All" tab allowing users to view images in all subdirectories in a single view.

Modified behavior of opts.image_browser_with_subdirs to ignore "All" tab since users would reasonably expect an "All" tab to show all images regardless of what the option was set to.

Fixed bug generating tabs_list when opts.image_browser_active_tabs option was present but no value was set resulting in no tabs being displayed. Added a check to verify opts.image_browser_active_tabs != "" and reset to default value