### PR TITLE
Tweak aspect ratio css workaround to apply only to image browser tab

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ div[id^="image_browser_tab"][id$="image_browser_gallery"].hide_loading > .svelte
 /* Workaround until gradio version is updated to a version that fixes it
    see https://github.com/gradio-app/gradio/issues/1590
 */
-.thumbnail-item > img {
+#tab_image_browser .thumbnail-item > img {
   width: auto !important;
   height: auto !important;
 }


### PR DESCRIPTION
Add id selector for image browser tab so the css rule doesn't crop thumbnails in other tabs (e.g. txt2img results pane)
<details>
  <summary>txt2img thumbnails show at full aspect ratio</summary>

![image](https://github.com/AlUlkesh/stable-diffusion-webui-images-browser/assets/796669/ed190b4b-56cc-45b4-a088-faf03ab14512)

</details>

<details>
  <summary>Image Browser Gallery still cropped square</summary>

![image](https://github.com/AlUlkesh/stable-diffusion-webui-images-browser/assets/796669/dc34259d-0217-4eea-bef8-a395d093f631)

</details>

This fixes #189 